### PR TITLE
docs: add Publish page & refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ coverage
 .docusaurus
 .cache-loader
 
-docs/Install.md
-docs/Quickstart.mdx
-docs/Enarx_toml.md
+Install.md
+Quickstart.mdx
+docs/Running/Publish.md
+docs/Running/Enarx_toml.md
+versioned_staging/Running/Enarx_toml.md

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -81,6 +81,10 @@ const config = {
                 to: '/docs/Quickstart',
               },
               {
+                label: 'Running Enarx',
+                to: '/docs/Running/Publish',
+              },
+              {
                 label: 'WebAssembly Guide',
                 to: '/docs/WebAssembly/Introduction',
               },
@@ -198,6 +202,10 @@ const config = {
               {
                 label: 'Installation Guide',
                 to: '/docs/QuickStart',
+              },
+              {
+                label: 'Running Enarx',
+                to: '/docs/Running/Publish',
               },
               {
                 label: 'WebAssembly Guide',

--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -9,10 +9,11 @@ echo "REF: ${REF}"
 git clone --branch ${REF} https://github.com/${ORG}/enarx.git versioned
 
 (test -d versioned/docs/ && rsync -avp --no-links --ignore-times versioned/docs/* versioned_staging) || echo versioned docs do not exist, skipping step
-(test -d versioned/crates/enarx-config/ && cp versioned/crates/enarx-config/Enarx_toml.md versioned_staging) || echo enarx_config versioned docs do not exist, skipping step
+if [ ! -d versioned_staging/Running ];then mkdir versioned_staging/Running; fi
+(test -d versioned/crates/enarx-config/ && cp versioned/crates/enarx-config/Enarx_toml.md versioned_staging/Running/Enarx_toml.md) || echo enarx_config versioned docs do not exist, skipping step
 (test -d versioned_staging && rsync -avp --no-links --ignore-times versioned_staging/* docs/) || echo versioned docs do not exist, skipping step
 (test -d override && rsync -avp --no-links --ignore-times override/* docs/) || echo override docs do not exist, skipping step
 
 yarn install
 yarn lint
-docusaurus build
+docusaurus build || npm run docusaurus build

--- a/hack/production.sh
+++ b/hack/production.sh
@@ -16,10 +16,11 @@ echo "RELEASE: ${release}"
 git clone  --branch "${release}" https://github.com/${ORG}/enarx.git versioned
 
 (test -d versioned/docs/ && rsync -avp --no-links --ignore-times versioned/docs/* versioned_staging) || echo versioned docs do not exist, skipping step
-(test -d versioned/crates/enarx-config/ && cp versioned/crates/enarx-config/Enarx_toml.md versioned_staging) || echo enarx_config versioned docs do not exist, skipping step
+if [ ! -d versioned_staging/Running ];then mkdir versioned_staging/Running; fi
+(test -d versioned/crates/enarx-config/ && cp versioned/crates/enarx-config/Enarx_toml.md versioned_staging/Running/Enarx_toml.md) || echo enarx_config versioned docs do not exist, skipping step
 (test -d versioned_staging && rsync -avp --no-links --ignore-times versioned_staging/* docs/) || echo versioned docs do not exist, skipping step
 (test -d override && rsync -avp --no-links --ignore-times override/* docs/) || echo override docs do not exist, skipping step
 
 yarn install
 yarn lint
-docusaurus build
+docusaurus build || npm run docusaurus build

--- a/override/Running/Enarx_toml.md
+++ b/override/Running/Enarx_toml.md
@@ -1,0 +1,129 @@
+# Configure Enarx.toml
+
+With the `Enarx.toml` configuration file, environment variables, arguments and pre-opened file descriptors
+can be passed to the WASM application.
+
+## Elements
+
+All elements are optional.
+
+### `env`
+
+`env` specifies the environment variables exported to the WASM application in a map.
+
+#### Example
+
+```toml
+env = { "FOO" = "foo", "BAR" = "bar" }
+```
+
+### `args`
+
+`args` specifies the arguments for the WASM application in an array.
+
+#### Example
+
+```toml
+args = [ "arg1", "arg2" ]
+```
+
+### `steward`
+
+`steward` specifies the URL for the steward to contact for a TLS certificate.
+
+#### Example
+
+```toml
+steward = "https://steward.example.com"
+```
+
+### `files`
+
+`files` specifies an array of file descriptor definitions to be pre-opened for the WASM application.
+
+A `files` entry can contain the following sub elements.
+
+#### `kind`
+
+`kind` can be one of `"null"`, `"stdin"`,`"stdout"`, `"stderr"`, `"listen"` or `"connect"`.
+
+#### `name`
+
+Name of the file descriptor, exported in the `FD_NAMES` environment variable.
+The default `name` for `kind`  `"null"`, `"stdin"`,`"stdout"`, `"stderr"` is the `kind`. 
+
+The `FD_NAMES` environment variable contains all `name` strings of the `files` array joined with ":".
+The `FD_COUNT` environment variable contains the number of `files` elements.
+
+#### `prot`
+
+`prot` can be `"tcp"` or `"tls"` for `kind = "connect"` or `kind = "listen"`.
+
+`"tls"` is the default, if `prot` is not specified.
+
+`tls` transparently wraps a TCP connection with the TLS protocol.
+For `kind = "listen"` every accepted connection is also wrapped with the TLS protocol. 
+
+#### `host`
+
+`host` specifies the host to connect to for a `kind = "connect"`
+
+#### `addr`
+
+`addr` specifies the address to bind to for a `kind = "listen"`.
+
+##### Examples
+
+```toml
+addr = "::"          # bind to any interface IPv6 and IPv4 (the default, if not specified)
+addr = "0.0.0.0"     # bind to any IPv4 interface
+addr = "::1"         # bind to IPv6 localhost
+addr = "127.0.0.1"   # bind to IPv4 localhost
+addr = "192.168.1.1" # bind to a specific IPv4 address
+```
+
+#### `port`
+
+`port` specifies the port to connect or bind to for `kind = "connect"` or `kind = "listen"`.
+The default value is `443`.
+
+## Example
+```toml
+env = { "VAR1" = "var1", "VAR2" = "var2" }
+args = [ "--argument1", "--argument2=foo" ]
+
+[[files]]
+kind = "null"
+
+[[files]]
+kind = "stdout"
+
+[[files]]
+kind = "stderr"
+
+[[files]]
+name = "LISTEN"
+kind = "listen"
+prot = "tls"
+port = 12345
+
+[[files]]
+name = "CONNECT"
+kind = "connect"
+prot = "tcp"
+host = "127.0.0.1"
+port = 23456
+```
+
+This configuration files passes the environment `VAR1=var1 VAR2=var2` and the arguments `--argument1 --argument2=foo` to the WASM application.
+
+Additionally, five file descriptors are pre-opened:
+- 0: `/dev/null`
+- 1: `/dev/stdout`
+- 2: `/dev/stderr`
+- 3: a TCP listen socket bound to port `12345` on address `::`, where every accepted connection is transparently wrapped with the TLS protocol 
+- 4: a normal TCP stream socket connected to `127.0.0.1:23456`
+
+Additionally, the following environment variables are exported:
+- `FD_COUNT=5`
+- `FD_NAMES=null:stdout:stderr:LISTEN:CONNECT`

--- a/override/Running/Publish.md
+++ b/override/Running/Publish.md
@@ -1,0 +1,83 @@
+# Publishing and deploying applications via Enarx
+
+Enarx is more than just a tool for running WebAssembly. It also allows you to publish a WebAssembly package to a remote package host, as well as securely run a published package in a local Enarx keep. The following sections will demonstrate this process, along with other useful commands for interacting with a package host.
+
+## Registering a user and authenticating with the package host
+
+Before we begin, you will need a GitHub account in order to authenticate to the package host.
+
+First, register a new user with the package host using the `enarx user register` command, as shown here:
+
+```
+enarx user register your_username
+```
+
+Upon entering this command, Enarx will print two things to your terminal: a web page URL, and a unique one-time code. Open the URL, then copy and paste the one-time code into the form field on the web page. Once you have entered the code, it will ask to connect to your GitHub account. Follow the instructions shown on the page, and when you have finished connecting your GitHub account you may close the page and return to your terminal. Note that it may take a few moments before your terminal finishes authenticating with GitHub. Once it does, it will notify you that your credentials have been saved locally. The command will then exit, indicating that your user account has been successfully registered.
+
+Note that in the future when you need to log in again (for example, if you are connecting from a different computer), you can do so with the `enarx user login` command, as shown here:
+
+```
+enarx user login
+```
+
+## Registering a new repository
+
+Before you can publish a package, you will first have to register the repository with the package host. You can do so with the `enarx repo register` command, as shown here:
+
+```
+enarx repo register your_username/your_reponame
+```
+
+In the above example, `your_username` is the username that you registered previously, and `your_reponame` is the name that you want this repository to have.
+
+## Publishing a WebAssembly package
+
+Before you can publish, you will first need to [compile your application to WebAssembly](WebAssembly/Introduction). At the end of this process you will have a file with the `.wasm` file extension. Rename this file to `main.wasm` and place it in the same directory as a properly configured [`Enarx.toml`](Enarx_toml).
+
+Once you have a directory containing a `main.wasm` and an `Enarx.toml`, we can *publish* this directory to the package host with the `enarx package publish` command, as shown here:
+
+```
+enarx package publish your_username/your_reponame:0.1.0 your_directory
+```
+
+In the above example, `0.1.0` is a *tag*, which identifies a unique version of the package being uploaded to this repository.
+
+## Running a published package
+
+Once a package has been published, it can be run directly with the `enarx deploy` command, as shown here:
+
+```
+enarx deploy some_username/some_reponame:0.1.0
+```
+
+Unlike `enarx repo register` and `enarx package publish`, this command does not require authentication and can be used with any public package.
+
+## Retrieving information about a user, repository, or package
+
+You can view information about repositories and packages via the `info` family of commands.
+
+The following command will show the tags of all packages published to a given repository:
+
+```
+enarx repo info some_username/some_reponame
+```
+
+The following command will show information about a specific package:
+
+```
+enarx package info some_username/some_reponame:0.1.0
+```
+
+## Manually specifying a package host
+
+All the previous examples in this document have made use of the default package host. However, it is also possible to specify other package hosts. Generally this is done by explicitly specifying a domain name as a prefix to the username. Here's an example of `enarx package info` using a non-default package host:
+
+```
+enarx package info example.com/some_username/some_reponame:0.1.0
+```
+
+Any valid domain name is permitted, and a port may be explicitly specified:
+
+```
+enarx package info localhost:1234/some_username/some_reponame
+```

--- a/sidebars.js
+++ b/sidebars.js
@@ -31,7 +31,7 @@ const sidebars = {
     {
       type: 'category',
       label: 'Running Enarx',
-      items: ['Running/Publish', 'Enarx_toml'],
+      items: ['Running/Publish', 'Running/Enarx_toml'],
     },
     {
       type: 'category',

--- a/sidebars.js
+++ b/sidebars.js
@@ -31,7 +31,7 @@ const sidebars = {
     {
       type: 'category',
       label: 'Running Enarx',
-      items: ['Enarx_toml'],
+      items: ['Running/Publish', 'Enarx_toml'],
     },
     {
       type: 'category',

--- a/versioned_staging/Running/Publish.md
+++ b/versioned_staging/Running/Publish.md
@@ -1,4 +1,4 @@
-# Publishing and deploying applications via Enarx
+# Publish & Deploy Apps
 
 Enarx is more than just a tool for running WebAssembly. It also allows you to publish a WebAssembly package to a remote package host, as well as securely run a published package in a local Enarx keep. The following sections will demonstrate this process, along with other useful commands for interacting with a package host.
 
@@ -32,7 +32,7 @@ In the above example, `your_username` is the username that you registered previo
 
 ## Publishing a WebAssembly package
 
-Before you can publish, you will first need to [compile your application to WebAssembly](WebAssembly/Introduction). At the end of this process you will have a file with the `.wasm` file extension. Rename this file to `main.wasm` and place it in the same directory as a properly configured [`Enarx.toml`](Enarx_toml).
+Before you can publish, you will first need to [compile your application to WebAssembly](../WebAssembly/Introduction). At the end of this process you will have a file with the `.wasm` file extension. Rename this file to `main.wasm` and place it in the same directory as a properly configured [`Enarx.toml`](Enarx_toml).
 
 Once you have a directory containing a `main.wasm` and an `Enarx.toml`, we can *publish* this directory to the package host with the `enarx package publish` command, as shown here:
 


### PR DESCRIPTION
Supersedes #41 

- Add `Publish.md` document
- Fix paths in `Publish.md` document
- Move Publish document to versioned_staging
- Move `Enarx_toml.md` into `Running/` subdirectory
- Update build scripts (`hack/preview.sh` & `hack/production.sh`) to add `Enarx_toml.md` to `Running/` subdirectory and support local builds (where `docusaurus` isn't added to path)
- Update top level menu to link to `Publish.md`
- Fix `sidebar.js` sidebar menu with correct paths
- `.gitignore` cleanup