### PR TITLE
feat: create link to Codex repo

### DIFF
--- a/docs/WebAssembly/AssemblyScript.md
+++ b/docs/WebAssembly/AssemblyScript.md
@@ -35,6 +35,9 @@ else{
 let a: i32 = fibo(7);
 Console.log(a.toString());
 ```
+:::tip
+Access the [AssemblyScript codex repository](https://github.com/enarx/codex/tree/main/AssemblyScript) for code samples, including the [fibonacci example](https://github.com/enarx/codex/tree/main/AssemblyScript/fibonacci).
+:::
 
 We need to import `wasi` to add some nice defaults for compiling to `WASI` and we need to import `Console` to write to `stdout`.
 

--- a/docs/WebAssembly/C++.md
+++ b/docs/WebAssembly/C++.md
@@ -28,6 +28,9 @@ int main(){
     cout << "Fibonacci Sequence term at " << n << "  " << "is " << FibonacciSequence(n) << endl;
 }
 ```
+:::tip
+Access the [C++ codex repository](https://github.com/enarx/codex/tree/main/C%2B%2B) for code samples, including the [fibonacci example](https://github.com/enarx/codex/tree/main/C%2B%2B/fibonacci).
+:::
 
 ## Compile the C++ code to Wasm
 

--- a/docs/WebAssembly/C.md
+++ b/docs/WebAssembly/C.md
@@ -28,6 +28,9 @@ int main(){
 }
 
 ```
+:::tip
+Access the [C codex repository](https://github.com/enarx/codex/tree/main/C) for code samples, including the [fibonacci example](https://github.com/enarx/codex/tree/main/C/fibonacci).
+:::
 
 ## Compile the C code to Wasm
 

--- a/docs/WebAssembly/Golang.md
+++ b/docs/WebAssembly/Golang.md
@@ -48,8 +48,11 @@ func main(){
     fmt.Println("Fibonacci of", n , "is", FibonacciRecursion(n));
 }
 
-
 ```
+:::tip
+Access the [Go codex repository](https://github.com/enarx/codex/tree/main/Go) for code samples, including the [fibonacci example](https://github.com/enarx/codex/tree/main/Go/fibonacci).
+:::
+
 ## Compile the Go code
 
 ```bash

--- a/docs/WebAssembly/Grain.md
+++ b/docs/WebAssembly/Grain.md
@@ -21,6 +21,9 @@ fibonacci(n - 1) + fibonacci(n - 2)
 
 print(fibonacci(7))
 ```
+:::tip
+Access the [Grain codex repository](https://github.com/enarx/codex/tree/main/Grain) for code samples, including the [fibonacci example](https://github.com/enarx/codex/tree/main/Grain/fibonacci).
+:::
 
 :::note
 The function is recursive with the keyword `rec` in Grain.

--- a/docs/WebAssembly/Introduction.md
+++ b/docs/WebAssembly/Introduction.md
@@ -6,18 +6,18 @@ Enarx provides a WebAssembly runtime, based on [wasmtime](https://wasmtime.dev/)
 
 This guide will show how to implement a [Fibonacci sequence](https://en.wikipedia.org/wiki/Fibonacci_number) in various languages and run it on Enarx.
 
-| Language  | Enarx support  |
-|---|---|
-| [Rust](Rust) | Excellent |
-| [C++](C++) | Excellent |
-| [C](C) | Excellent |
-| [Golang](Golang) | Excellent |
-| [Ruby](Ruby) | Experimental |
-| [.NET](dotnet) | Experimental |
-| [Python](Python) | Experimental |
-| [JavaScript](JavaScript) | Experimental |
-| [TypeScript](TypeScript) | Experimental |
-| [AssemblyScript](AssemblyScript) | Excellent |
-| [Swift](Swift) | Experimental |
-| [Grain](Grain) | Experimental |
-| [Zig](Zig) | Excellent |
+| Wasm guide  | Codex Repo  | Enarx Support|
+|---|---|---|
+| [Rust](Rust) | [Repo](https://github.com/enarx/codex/tree/main/Rust) | Yes |
+| [C++](C++) | [Repo](https://github.com/enarx/codex/tree/main/C%2B%2B) | Yes |
+| [C](C) | [Repo](https://github.com/enarx/codex/tree/main/C) | Yes |
+| [Golang](Golang) | [Repo](https://github.com/enarx/codex/tree/main/Go) | Yes |
+| [Ruby](Ruby) | [Repo](https://github.com/enarx/codex/tree/main/Ruby) | Experimental |
+| [.NET](dotnet) | [Repo](https://github.com/enarx/codex/tree/main/C%23) | Experimental |
+| [Python](Python) | [Repo](https://github.com/enarx/codex/tree/main/Python) | Experimental |
+| [JavaScript](JavaScript) | [Repo](https://github.com/enarx/codex/tree/main/JavaScript) | Experimental |
+| [TypeScript](TypeScript) | [Repo](https://github.com/enarx/codex/tree/main/TypeScript) | Experimental |
+| [AssemblyScript](AssemblyScript) | [Repo](https://github.com/enarx/codex/tree/main/AssemblyScript) | Experimental |
+| [Swift](Swift) | [Repo](https://github.com/enarx/codex/tree/main/Swift) | Experimental |
+| [Grain](Grain) | [Repo](https://github.com/enarx/codex/tree/main/Grain) | Experimental |
+| [Zig](Zig) | [Repo](https://github.com/enarx/codex/tree/main/Zig) | Experimental |

--- a/docs/WebAssembly/JavaScript.md
+++ b/docs/WebAssembly/JavaScript.md
@@ -34,6 +34,9 @@ var Shopify = {
   main: fibonacci
 };
 ```
+:::tip
+Access the [JavaScript codex repository](https://github.com/enarx/codex/tree/main/JavaScript) for code samples, including the [fibonacci example](https://github.com/enarx/codex/tree/main/JavaScript/fibonacci).
+:::
 
 :::note
 The Javy toolchain expects `Shopify.main` to point to our main function, in this case, `fibonacci`.

--- a/docs/WebAssembly/Python.md
+++ b/docs/WebAssembly/Python.md
@@ -46,6 +46,9 @@ else:
        n2 = nth
        count += 1
 ```
+:::tip
+Access the [Python codex repository](https://github.com/enarx/codex/tree/main/Python) for code samples, including the [fibonacci example](https://github.com/enarx/codex/tree/main/Python/fibonacci).
+:::
 
 ## Run with Wasmtime
 - Change directory to the **root python-wasi source directory**.

--- a/docs/WebAssembly/Ruby.md
+++ b/docs/WebAssembly/Ruby.md
@@ -21,6 +21,9 @@ def fibonacci( n )
 end
 puts fibonacci( 5 )
 ```
+:::tip
+Access the [Ruby codex repository](https://github.com/enarx/codex/tree/main/Ruby) for code samples, including the [fibonacci example](https://github.com/enarx/codex/tree/main/Ruby/fibonacci).
+:::
 
 Save it to: `head-wasm32-unknown-wasi-full/src/fibonacci.rb`
 

--- a/docs/WebAssembly/Rust.md
+++ b/docs/WebAssembly/Rust.md
@@ -47,6 +47,9 @@ fn fib (n: u32) -> u32 {
 }
   
 ```
+:::tip
+Access the [Rust codex repository](https://github.com/enarx/codex/tree/main/Rust) for code samples, including the [fibonacci example](https://github.com/enarx/codex/tree/main/Rust/fibonacci).
+:::
 
 ## Compile Rust
 

--- a/docs/WebAssembly/Swift.md
+++ b/docs/WebAssembly/Swift.md
@@ -28,6 +28,9 @@ return a
 
 print(fibonacci(n:7))
 ```
+:::tip
+Access the [Swift codex repository](https://github.com/enarx/codex/tree/main/Swift) for code samples, including the [fibonacci example](https://github.com/enarx/codex/tree/main/Swift/fibonacci).
+:::
 
 ## Compile Swift to Wasm
 

--- a/docs/WebAssembly/TypeScript.md
+++ b/docs/WebAssembly/TypeScript.md
@@ -28,6 +28,9 @@ function fibonacci(num: number) {
     console.log("Fibonacci Term is:", b);
 }
 ```
+:::tip
+Access the [TypeScript codex repository](https://github.com/enarx/codex/tree/main/TypeScript) for code samples, including the [fibonacci example](https://github.com/enarx/codex/tree/main/TypeScript/fibonacci).
+:::
 
 ## Transpiling TypeScript to JavaScript
 

--- a/docs/WebAssembly/Zig.md
+++ b/docs/WebAssembly/Zig.md
@@ -26,6 +26,10 @@ pub fn main() !void {
     try stdout.print("is: {d} \n ", .{fibonacci(x)}  );
 }
 ```
+:::tip
+Access the [Zig codex repository](https://github.com/enarx/codex/tree/main/Zig) for code samples, including the [fibonacci example](https://github.com/enarx/codex/tree/main/Zig/fibonacci).
+:::
+
 ## Compile the Zig code
 
 ```bash

--- a/docs/WebAssembly/dotnet.md
+++ b/docs/WebAssembly/dotnet.md
@@ -49,6 +49,10 @@ namespace MyFirstWasiApp
     }
 }
 ```
+:::tip
+Access the [C# codex repository](https://github.com/enarx/codex/tree/main/C%23) for code samples, including the [fibonacci example](https://github.com/enarx/codex/tree/main/C%23/fibonacci).
+:::
+
 :::note
 Currently `Experimental WASI SDK` does not allow to take user input through the console using `ReadLine()`.
 :::


### PR DESCRIPTION
For each language in the WebAssembly Guide, create a link to the corresponding Codex repo.

Fixes #55 

Signed-off-by: Nick Vidal <nick@profian.com>