### PR TITLE
docs: update references in Technical Overview and add Profian

### DIFF
--- a/docs/Technical/Components.md
+++ b/docs/Technical/Components.md
@@ -13,7 +13,7 @@ The following components are relevant or related to Enarx:
 ## Attestation
 An application which is going to run in an Enarx Keep needs to attest two things:
 1. The hardware TEE (Trusted Execution Environment) providing Keeps.
-1. A measurement of the Enarx runtime.  This means that Red Hat may need to launch a service to abstract attestation. The way that this works is that the client requests attestation from Enarx.  Enarx supplies a blob. The client forwards this to Red Hat. Red Hat will then complete attestation of the h/w environment and translate the measurements of Enarx into a something which allows you to identify the specific version of Enarx.
+1. A measurement of the Enarx runtime.  This means that Profian may need to launch a service to abstract attestation. The way that this works is that the client requests attestation from Enarx.  Enarx supplies a blob. The client forwards this to Profian. Profian will then complete attestation of the h/w environment and translate the measurements of Enarx into a something which allows you to identify the specific version of Enarx.
 
 
 From the client’s point of view, the attestation steps of Enarx end up with the following two cryptographically validated assertions:

--- a/docs/Technical/FAQ.md
+++ b/docs/Technical/FAQ.md
@@ -49,7 +49,7 @@ Secondly, it is likely to be impossible to mitigate all side-channel attacks, bu
 ## How can I contribute?
 You can find information on how to get started over at [How to contribute](/docs/Contributing/Introduction).
 
-## Does Red Hat own Enarx?
+## Does Profian own Enarx?
 No single company or organisation "owns" Enarx.  It's open source software.   Copyright on code is owned by whoever contributes it to the project.  For more information, try [this definition](https://opensource.com/resources/what-open-source) from [Opensource.com](https://opensource.com) or our [license page](https://github.com/enarx/enarx/blob/main/LICENSE) (spoiler: it's Apache 2.0).
 
 ## Who writes this stuff?


### PR DESCRIPTION
Add references to Profian. For example, "Does Profian own Enarx?" in F.A.Q.

Signed-off-by: Nick Vidal <nick@profian.com>