### PR TITLE
docs: update Wasm Guide with tables

### DIFF
--- a/docs/WebAssembly/AssemblyScript.md
+++ b/docs/WebAssembly/AssemblyScript.md
@@ -1,5 +1,10 @@
 # WebAssembly with AssemblyScript
 
+:::note
+* AssemblyScript was designed for WebAssembly and has a syntax similar to TypeScript. 
+* Support for WASI is uncertain, given that the AssemblyScript team has [criticized](https://www.assemblyscript.org/standards-objections.html) the WASI standardization process.
+:::
+
 ## Install AssemblyScript
 
 To install AssemblyScript on your local system, run the command:

--- a/docs/WebAssembly/C++.md
+++ b/docs/WebAssembly/C++.md
@@ -1,5 +1,12 @@
 # WebAssembly with C++
 
+:::note
+* WebAssembly support for C++ is excellent.
+* C/C++ are among the most popular languages to work with WebAssembly.
+* The [WASI SDK](https://github.com/WebAssembly/wasi-sdk/) toolchain is maintained by the Bytecode Alliance.
+* WASI SDK pulls upstream projects Clang and LLVM, as well as wasi-libc. 
+:::
+
 ## Install WASI SDK
 
 Install [WASI SDK](https://github.com/WebAssembly/wasi-sdk/) following the instructions:

--- a/docs/WebAssembly/C.md
+++ b/docs/WebAssembly/C.md
@@ -1,5 +1,12 @@
 # WebAssembly With C 
 
+:::note
+* WebAssembly support for C is excellent.
+* C/C++ are among the most popular languages to work with WebAssembly.
+* The [WASI SDK](https://github.com/WebAssembly/wasi-sdk/) toolchain is maintained by the Bytecode Alliance.
+* WASI SDK pulls upstream projects Clang and LLVM, as well as wasi-libc. 
+:::
+
 ## Install WASI SDK
 
 Install [WASI SDK](https://github.com/WebAssembly/wasi-sdk/) following the instructions:

--- a/docs/WebAssembly/Golang.md
+++ b/docs/WebAssembly/Golang.md
@@ -1,10 +1,16 @@
 # WebAssembly with Golang
 
+:::note
+* WebAssembly support for Go is excellent thanks to [TinyGo](https://tinygo.org/).
+* TinyGo provides a compiler based on LLVM.
+* Go is among the most popular and the second most desirable language to work with WebAssembly (using wasmtime).
+:::
+
 ## Install Golang
 
 Go to [go.dev](https://go.dev/) and follow the instructions.
 
-## Install Tinygo
+## Install TinyGo
 
 A Go compiler intended for use in small places such as microcontrollers, WebAssembly (Wasm), and command-line tools
 

--- a/docs/WebAssembly/Grain.md
+++ b/docs/WebAssembly/Grain.md
@@ -1,5 +1,9 @@
 # WebAssembly with Grain
 
+:::note
+* Grain is a functional programming language designed for WebAssembly.
+:::
+
 ## Install Grain
 
 To install Grain, follow the instructions here:

--- a/docs/WebAssembly/Introduction.md
+++ b/docs/WebAssembly/Introduction.md
@@ -2,22 +2,106 @@
 
 [WebAssembly](https://webassembly.org/) (abbreviated Wasm) is a binary instruction format for a stack-based virtual machine. Wasm is designed as a portable target for compilation of various programming languages.
 
-Enarx provides a WebAssembly runtime, based on [wasmtime](https://wasmtime.dev/), offering developers a wide range of language choices for implementation, including Rust, C, C++, and Go.
+Enarx provides a WebAssembly runtime, based on [wasmtime](https://wasmtime.dev/), offering developers a wide range of language choices for implementation.
 
-This guide will show how to implement a [Fibonacci sequence](https://en.wikipedia.org/wiki/Fibonacci_number) in various languages and run it on Enarx.
+[WASI](https://wasi.dev/) (WebAssembly System Interface) is an API that provides access to several operating-system-like features, including I/O, filesystem, sockets, threads, and crypto.
 
-| Wasm guide  | Codex Repo  | Enarx Support|
-|---|---|---|
-| [Rust](Rust) | [Repo](https://github.com/enarx/codex/tree/main/Rust) | Yes |
-| [C++](C++) | [Repo](https://github.com/enarx/codex/tree/main/C%2B%2B) | Yes |
-| [C](C) | [Repo](https://github.com/enarx/codex/tree/main/C) | Yes |
-| [Golang](Golang) | [Repo](https://github.com/enarx/codex/tree/main/Go) | Yes |
-| [Ruby](Ruby) | [Repo](https://github.com/enarx/codex/tree/main/Ruby) | Experimental |
-| [.NET](dotnet) | [Repo](https://github.com/enarx/codex/tree/main/C%23) | Experimental |
-| [Python](Python) | [Repo](https://github.com/enarx/codex/tree/main/Python) | Experimental |
-| [JavaScript](JavaScript) | [Repo](https://github.com/enarx/codex/tree/main/JavaScript) | Experimental |
-| [TypeScript](TypeScript) | [Repo](https://github.com/enarx/codex/tree/main/TypeScript) | Experimental |
-| [AssemblyScript](AssemblyScript) | [Repo](https://github.com/enarx/codex/tree/main/AssemblyScript) | Experimental |
-| [Swift](Swift) | [Repo](https://github.com/enarx/codex/tree/main/Swift) | Experimental |
-| [Grain](Grain) | [Repo](https://github.com/enarx/codex/tree/main/Grain) | Experimental |
-| [Zig](Zig) | [Repo](https://github.com/enarx/codex/tree/main/Zig) | Experimental |
+Support for WebAssembly and WASI (WebAssembly System Interface) varies from language to language.
+
+## Enarx Tier, Wasm Guide, and Codex Repository
+
+The following table shows Enarx support and tier information for each language, as well as links to a dedicated Wasm Guide and to the Codex repository with code examples.
+
+| Wasm Guide  | Codex Repo  | Enarx Support | Enarx Tier |
+|---|---|---|---|
+| [Rust](Rust) | [Repo](https://github.com/enarx/codex/tree/main/Rust) | Excellent | Tier 1 |
+| [C++](C++) | [Repo](https://github.com/enarx/codex/tree/main/C%2B%2B) | Excellent | Tier 1 |
+| [C](C) | [Repo](https://github.com/enarx/codex/tree/main/C) | Excellent | Tier 1 |
+| [Golang](Golang) | [Repo](https://github.com/enarx/codex/tree/main/Go) | Excellent | Tier 1 |
+| [JavaScript](JavaScript) | [Repo](https://github.com/enarx/codex/tree/main/JavaScript) | Experimental | Tier 2 |
+| [TypeScript](TypeScript) | [Repo](https://github.com/enarx/codex/tree/main/TypeScript) | Experimental | Tier 2 |
+| [Python](Python) | [Repo](https://github.com/enarx/codex/tree/main/Python) | Experimental | Tier 2 |
+| [.NET](dotnet) | [Repo](https://github.com/enarx/codex/tree/main/C%23) | Experimental | Tier 2 |
+| [Java](Java) | [Repo](https://github.com/enarx/codex/tree/main/Java) | Experimental | Tier 2 |
+| [Ruby](Ruby) | [Repo](https://github.com/enarx/codex/tree/main/Ruby) | Experimental | Tier 3 |
+| [Swift](Swift) | [Repo](https://github.com/enarx/codex/tree/main/Swift) | Experimental | Tier 3 |
+| [AssemblyScript](AssemblyScript) | [Repo](https://github.com/enarx/codex/tree/main/AssemblyScript) | Experimental | Tier 3 |
+| [Grain](Grain) | [Repo](https://github.com/enarx/codex/tree/main/Grain) | Experimental | Tier 3 |
+| [Zig](Zig) | [Repo](https://github.com/enarx/codex/tree/main/Zig) | Experimental | Tier 3 |
+
+Enarx support for Rust, C, C++, and Go are excellent (Tier 1). Other languages are experimental and are ranked either Tier 2 or Tier 3 based on their Wasm/WASI support, overall popularity, as well as their Wasm/WASI popularity and desirability. Please select each language to learn more, or read the next sections to compare different languages.
+
+
+## Wasm/WASI Popularity and Desirability
+
+[The State of WebAssembly](https://blog.scottlogic.com/2022/06/20/state-of-wasm-2022.html) is an annual survey that provides an overview of the Wasm landscape, including language popularity (current usage) and desirability (future).
+
+The Enarx team has explored the [data](https://wasmweekly.news/assets/state-of-webassembly-2022.csv) and further analysed it specifically for respondents who are using wasmtime (the runtime used by Enarx). The table with the results are presented below:
+
+| Language | Popularity (wasmtime) | Desirability (wasmtime) | Overall Popularity |
+|---|---|---|------|
+| [Rust](Rust) |44% use frequently|68% are a lot interested|#19 on RedMonk's rank|
+| [C++](C++) |10%|17%|#7|
+| [C](C) |10%|17%|#10|
+| [Golang](Golang) |7%|32%|#16|
+| [JavaScript](JavaScript) |13%|25%|#1|
+| [TypeScript](TypeScript) |13%|25%|#1|
+| [Python](Python) |3%|22%|#2|
+| [.NET](dotnet) |2%|13%|#5|
+| [Java](Java) |2%|9%|#3|
+| [Ruby](Ruby) |1%|9%|#9|
+| [Swift](Swift) |2%|9%|#11|
+| [AssemblyScript](AssemblyScript) |7%|19%|-|
+| [Grain](Grain) |1%|9%|-|
+| [Zig](Zig) |2%|12%|-|
+
+Additionally, the Enarx team has combined the Wasm/WASI popularity/desirability presented above with the overall popularity of each language according to the [RedMonk Programming Language Rankings](https://redmonk.com/sogrady/2022/03/28/language-rankings-1-22/). In the RedMonk's ranking, the most popular languages are, in order: JavaScript, Python, Java, PHP, C#, C++, TypeScript, Ruby, C, Swift, C, Swift, R, Objective-C, Shell, Scala, Go, PowerShell, Kotlin, Rust, and Dart. 
+
+## WASI Support
+
+:::note
+This section is a work in progress. 
+:::
+
+The Enarx team is developing a table to show WASI support for various programming languages:
+
+| Language  | I/O | Filesystem | Sockets | Threads | Crypto |
+|---|---|---|---|---|---|
+| [Rust](Rust) |---|---|---|---|---|
+| [C++](C++) |---|---|---|---|---|
+| [C](C) |---|---|---|---|---|
+| [Golang](Golang) |---|---|---|---|---|
+| [JavaScript](JavaScript) |---|---|---|---|---|
+| [TypeScript](TypeScript) |---|---|---|---|---|
+| [Python](Python) |---|---|---|---|---|
+| [.NET](dotnet) |---|---|---|---|---|
+| [Java](Java) |---|---|---|---|---|
+| [Ruby](Ruby) |---|---|---|---|---|
+| [Swift](Swift) |---|---|---|---|---|
+| [AssemblyScript](AssemblyScript) |---|---|---|---|---|
+| [Grain](Grain) |---|---|---|---|---|
+| [Zig](Zig) |---|---|---|---|---|
+
+## Benchmarking
+
+:::note
+This section is a work in progress. 
+:::
+
+The Enarx team is creating a testing framework that will automatically generate a table showing information such as Wasm file size, compilation time, and execution time for each language. This framework will run code samples from the [Codex repository](https://github.com/enarx/codex/).
+
+| Language  | Wasm File Size | Compilation Time | Execution Time |
+|---|---|---|---|
+| [Rust](Rust) |---|---|---|
+| [C++](C++) |---|---|---|
+| [C](C) |---|---|---|
+| [Golang](Golang) |---|---|---|
+| [Ruby](Ruby) |---|---|---|
+| [.NET](dotnet) |---|---|---|
+| [Python](Python) |---|---|---|
+| [JavaScript](JavaScript) |---|---|---|
+| [TypeScript](TypeScript) |---|---|---|
+| [AssemblyScript](AssemblyScript) |---|---|---|
+| [Swift](Swift) |---|---|---|
+| [Grain](Grain) |---|---|---|
+| [Zig](Zig) |---|---|---|

--- a/docs/WebAssembly/Java.md
+++ b/docs/WebAssembly/Java.md
@@ -1,0 +1,26 @@
+# WebAssembly with Java
+
+:::note
+In progress
+:::
+
+## Install Java
+
+## Java code
+
+The fibonacci code in Java is:
+
+
+```java
+```
+:::tip
+Access the [Java codex repository](https://github.com/enarx/codex/tree/main/Java) for code samples, including the [fibonacci example](https://github.com/enarx/codex/tree/main/Java/fibonacci).
+:::
+
+## Compile Java code to Wasm
+
+## Run with Enarx
+
+```
+enarx run fibo.wasm
+```

--- a/docs/WebAssembly/JavaScript.md
+++ b/docs/WebAssembly/JavaScript.md
@@ -1,5 +1,12 @@
 # WebAssembly with JavaScript
 
+:::note
+* WebAssembly support for JavaScript is good thanks to [Javy](https://github.com/Shopify/javy).
+* Javy compiles [QuickJS](https://bellard.org/quickjs/), a tiny JavaScript runtime, to Wasm, along with script to be executed. 
+* JavaScript is the second most popular and desirable language to work with WebAssembly.
+* TypeScript, a superset of JavaScript, can be transpiled into JavaScript before being compiled to Wasm.
+:::
+
 ## Install Javy
 
 Install Javy following the instructions here:

--- a/docs/WebAssembly/Python.md
+++ b/docs/WebAssembly/Python.md
@@ -1,5 +1,13 @@
 # WebAssembly with Python
 
+:::note
+* WebAssembly support for Python is good thanks to [CPython on wasm32-wasi](https://github.com/singlestore-labs/python-wasi/).
+* CPython on wasm32-wasi consists of utilities and libraries for building [CPython](https://github.com/python/cpython) sources for the WebAssembly platform using the [WASI SDK](https://github.com/WebAssembly/wasi-sdk) and [wasix](https://github.com/singlestore-labs/wasix).
+* Python is one of the most desirable languages to work with WebAssembly.
+* The Python interpreter needs to be compiled to Wasm, and Python libraries should be available from the VFS (virtual filesystem).
+* Currently Python works with wasmtime, and should work with Enarx once it has VFS support.
+:::
+
 ## Environment Setup
 
 ### Docker

--- a/docs/WebAssembly/Ruby.md
+++ b/docs/WebAssembly/Ruby.md
@@ -1,5 +1,12 @@
 # WebAssembly with Ruby
 
+:::note
+* WebAssembly support for Ruby is good thanks to [ruby.wasm](https://github.com/ruby/ruby.wasm/).
+* ruby.wasm is a collection of WebAssembly ports of the CRuby. It enables running Ruby applications on WASI compatible WebAssembly runtimes.
+* It uses [wasi-vfs](https://github.com/kateinoigakukun/wasi-vfs/) to create a virtual filesystem layer for WASI.
+* Sockets and threads are not supported yet.
+:::
+
 ## Install wasi-vfs and ruby.wasm
 
 Install wasi-vfs and ruby.wasm following the instructions here:

--- a/docs/WebAssembly/Rust.md
+++ b/docs/WebAssembly/Rust.md
@@ -1,5 +1,12 @@
 # WebAssembly with Rust
 
+:::note
+* WebAssembly support for Rust is excellent.
+* Rust is the most popular and desirable language to work with WebAssembly.
+* Both Enarx and wasmtime (Enarx's runtime) are written in Rust.
+* The Enarx team has contributed upstream to WASI sockets, threads, and crypto.
+:::
+
 ## Install Rust
 
 To install Rust, go to [rust-lang.org](https://www.rust-lang.org/tools/install) and follow the instructions using rustup.

--- a/docs/WebAssembly/Swift.md
+++ b/docs/WebAssembly/Swift.md
@@ -1,5 +1,10 @@
 # WebAssembly with Swift
 
+:::note
+* WebAssembly support for Swift is good thanks to [SwiftWasm](https://swiftwasm.org/).
+* SwiftWasm compiles Swift code to WebAssembly.
+:::
+
 ## Install Swift
 
 To install Docker on your local system, refer the [official guide](https://docs.docker.com/get-docker/).

--- a/docs/WebAssembly/TypeScript.md
+++ b/docs/WebAssembly/TypeScript.md
@@ -1,6 +1,11 @@
 # WebAssembly with TypeScript
 
-TypeScript is a superset of JavaScript. Therefore, the best approach to using TypeScript in WebAssembly is to transpile it into JavaScript.
+:::note
+* TypeScript is a superset of JavaScript. Therefore, the best approach to using TypeScript in WebAssembly is to transpile it into JavaScript.
+* WebAssembly support for JavaScript is good thanks to [Javy](https://github.com/Shopify/javy).
+* Javy compiles [QuickJS](https://bellard.org/quickjs/), a tiny JavaScript runtime, to Wasm, along with script to be executed. 
+* JavaScript is the second most popular and desirable language to work with WebAssembly.
+:::
 
 ## Install TypeScript compiler 
 

--- a/docs/WebAssembly/Zig.md
+++ b/docs/WebAssembly/Zig.md
@@ -1,5 +1,10 @@
 # WebAssembly with Zig
 
+:::note
+* WebAssembly support for Zig is excellent.
+* Zig uses LLVM, thus it provides wasm32 target architecture.
+:::
+
 ## Install Zig
 
 To install Zig, follow the instructions here:

--- a/docs/WebAssembly/dotnet.md
+++ b/docs/WebAssembly/dotnet.md
@@ -1,5 +1,10 @@
 # WebAssembly With .NET 
 
+:::note
+* WebAssembly support for .NET is good thanks to the [dotnet WASI SDK](https://github.com/SteveSandersonMS/dotnet-wasi-sdk).
+* dotnet WASI SDK is an experimental package that can build .NET Core projects (including whole ASP.NET Core applications) into standalone WASI-compliant .wasm files.
+:::
+
 ## Install .NET Preview (7.0.0-preview.4)
 
 You can download .NET and follow installation instructions here:


### PR DESCRIPTION
Update Wasm Guide with the following tables:
- Enarx Tier, Wasm Guide, and Codex Repository
- Wasm/WASI Popularity and Desirability
- WASI Support
- Benchmarking

Additionally, provide notes for each language.

Signed-off-by: Nick Vidal <nick@profian.com>