### PR TITLE
docs: fix typos on Wasm guide

### DIFF
--- a/docs/WebAssembly/AssemblyScript.md
+++ b/docs/WebAssembly/AssemblyScript.md
@@ -13,7 +13,7 @@ To install AssemblyScript on your local system, run the command:
 npm install -g assemblyscript
 ```
 
-We also need to install `as-wasi`. It is an easy to use API for the AssemblyScript WASI bindings. By bindings, we mean the declared functions that would map to the `WASI` host functions. The command to do the same is :
+We also need to install `as-wasi`. It is an easy to use API for the AssemblyScript WASI bindings. By bindings, we mean the declared functions that would map to the `WASI` host functions. The command to do the same is:
 
 ```
 npm install --save as-wasi
@@ -43,7 +43,7 @@ We need to import `wasi` to add some nice defaults for compiling to `WASI` and w
 
 ## Compile AssemblyScript code to Wasm
 
-To compile your AssemblyScript code, simply run :
+To compile your AssemblyScript code, simply run:
 
 ```
 asc fibo.ts -o fibo.wasm

--- a/docs/WebAssembly/C++.md
+++ b/docs/WebAssembly/C++.md
@@ -4,7 +4,7 @@
 * WebAssembly support for C++ is excellent.
 * C/C++ are among the most popular languages to work with WebAssembly.
 * The [WASI SDK](https://github.com/WebAssembly/wasi-sdk/) toolchain is maintained by the Bytecode Alliance.
-* WASI SDK pulls upstream projects Clang and LLVM, as well as wasi-libc. 
+* WASI SDK pulls upstream projects [Clang](https://clang.llvm.org/) and [LLVM](https://llvm.org/), as well as [wasi-libc](https://github.com/WebAssembly/wasi-libc).  
 :::
 
 ## Install WASI SDK

--- a/docs/WebAssembly/C.md
+++ b/docs/WebAssembly/C.md
@@ -4,7 +4,7 @@
 * WebAssembly support for C is excellent.
 * C/C++ are among the most popular languages to work with WebAssembly.
 * The [WASI SDK](https://github.com/WebAssembly/wasi-sdk/) toolchain is maintained by the Bytecode Alliance.
-* WASI SDK pulls upstream projects Clang and LLVM, as well as wasi-libc. 
+* WASI SDK pulls upstream projects [Clang](https://clang.llvm.org/) and [LLVM](https://llvm.org/), as well as [wasi-libc](https://github.com/WebAssembly/wasi-libc). 
 :::
 
 ## Install WASI SDK

--- a/docs/WebAssembly/Golang.md
+++ b/docs/WebAssembly/Golang.md
@@ -12,8 +12,6 @@ Go to [go.dev](https://go.dev/) and follow the instructions.
 
 ## Install TinyGo
 
-A Go compiler intended for use in small places such as microcontrollers, WebAssembly (Wasm), and command-line tools
-
 Go to [tinygo.org](https://tinygo.org/getting-started/install/) and follow the instructions.
 
 :::note

--- a/docs/WebAssembly/Introduction.md
+++ b/docs/WebAssembly/Introduction.md
@@ -29,18 +29,18 @@ The following table shows Enarx support and tier information for each language, 
 | [Grain](Grain) | [Repo](https://github.com/enarx/codex/tree/main/Grain) | Experimental | Tier 3 |
 | [Zig](Zig) | [Repo](https://github.com/enarx/codex/tree/main/Zig) | Experimental | Tier 3 |
 
-Enarx support for Rust, C, C++, and Go are excellent (Tier 1). Other languages are experimental and are ranked either Tier 2 or Tier 3 based on their Wasm/WASI support, overall popularity, as well as their Wasm/WASI popularity and desirability. Please select each language to learn more, or read the next sections to compare different languages.
+Enarx support for Rust, C, C++, and Go are excellent (Tier 1). Other languages are experimental and are ranked either Tier 2 or Tier 3 based on their Wasm/WASI support, overall popularity, as well as their Wasm/WASI popularity and desirability. Please select each language to view the dedicated Wasm Guide, or read the next sections to compare the different languages.
 
 
 ## Wasm/WASI Popularity and Desirability
 
 [The State of WebAssembly](https://blog.scottlogic.com/2022/06/20/state-of-wasm-2022.html) is an annual survey that provides an overview of the Wasm landscape, including language popularity (current usage) and desirability (future).
 
-The Enarx team has explored the [data](https://wasmweekly.news/assets/state-of-webassembly-2022.csv) and further analysed it specifically for respondents who are using wasmtime (the runtime used by Enarx). The table with the results are presented below:
+The Enarx team has explored the [data](https://wasmweekly.news/assets/state-of-webassembly-2022.csv) and created a [report](https://docs.google.com/spreadsheets/d/11uWt7C8MBp9sgSbXEVntbf1VRJ_-yHkChw0TeXoppEY/edit#gid=693866223) specifically for respondents who are using wasmtime (the runtime used by Enarx). The table with the results are presented below:
 
 | Language | Popularity (wasmtime) | Desirability (wasmtime) | Overall Popularity |
 |---|---|---|------|
-| [Rust](Rust) |44% use frequently|68% are a lot interested|#19 on RedMonk's rank|
+| [Rust](Rust) |44% use frequently|68% are a lot interested|#19 in RedMonk ranking|
 | [C++](C++) |10%|17%|#7|
 | [C](C) |10%|17%|#10|
 | [Golang](Golang) |7%|32%|#16|
@@ -55,7 +55,7 @@ The Enarx team has explored the [data](https://wasmweekly.news/assets/state-of-w
 | [Grain](Grain) |1%|9%|-|
 | [Zig](Zig) |2%|12%|-|
 
-Additionally, the Enarx team has combined the Wasm/WASI popularity/desirability presented above with the overall popularity of each language according to the [RedMonk Programming Language Rankings](https://redmonk.com/sogrady/2022/03/28/language-rankings-1-22/). In the RedMonk's ranking, the most popular languages are, in order: JavaScript, Python, Java, PHP, C#, C++, TypeScript, Ruby, C, Swift, C, Swift, R, Objective-C, Shell, Scala, Go, PowerShell, Kotlin, Rust, and Dart. 
+Additionally, the Enarx team has combined the Wasm/WASI popularity/desirability presented above with the overall popularity of each language according to the [RedMonk Programming Language Rankings](https://redmonk.com/sogrady/2022/03/28/language-rankings-1-22/). In the RedMonk rankings, the most popular languages are, in order: JavaScript, Python, Java, PHP, C#, C++, TypeScript, Ruby, C, Swift, C, Swift, R, Objective-C, Shell, Scala, Go, PowerShell, Kotlin, Rust, and Dart. 
 
 ## WASI Support
 

--- a/docs/WebAssembly/Java.md
+++ b/docs/WebAssembly/Java.md
@@ -1,7 +1,8 @@
 # WebAssembly with Java
 
 :::note
-In progress
+* This page is a work in progress  
+* There is a a friendly [fork](https://github.com/fermyon/teavm-wasi) of [TeaVM](https://teavm.org/), modified to support WASI and the WebAssembly Component Model proposal.
 :::
 
 ## Install Java

--- a/docs/WebAssembly/JavaScript.md
+++ b/docs/WebAssembly/JavaScript.md
@@ -2,7 +2,7 @@
 
 :::note
 * WebAssembly support for JavaScript is good thanks to [Javy](https://github.com/Shopify/javy).
-* Javy compiles [QuickJS](https://bellard.org/quickjs/), a tiny JavaScript runtime, to Wasm, along with script to be executed. 
+* Javy compiles [QuickJS](https://bellard.org/quickjs/), a tiny JavaScript runtime, to Wasm along with the script to be executed. 
 * JavaScript is the second most popular and desirable language to work with WebAssembly.
 * TypeScript, a superset of JavaScript, can be transpiled into JavaScript before being compiled to Wasm.
 :::

--- a/docs/WebAssembly/TypeScript.md
+++ b/docs/WebAssembly/TypeScript.md
@@ -1,9 +1,9 @@
 # WebAssembly with TypeScript
 
 :::note
-* TypeScript is a superset of JavaScript. Therefore, the best approach to using TypeScript in WebAssembly is to transpile it into JavaScript.
+* TypeScript is a superset of JavaScript. Therefore, the best approach to using TypeScript with WebAssembly is to transpile it into JavaScript.
 * WebAssembly support for JavaScript is good thanks to [Javy](https://github.com/Shopify/javy).
-* Javy compiles [QuickJS](https://bellard.org/quickjs/), a tiny JavaScript runtime, to Wasm, along with script to be executed. 
+* Javy compiles [QuickJS](https://bellard.org/quickjs/), a tiny JavaScript runtime, to Wasm along with the script to be executed. 
 * JavaScript is the second most popular and desirable language to work with WebAssembly.
 :::
 


### PR DESCRIPTION
Fix small typos and add updates to the Wasm guide.

Signed-off-by: Nick Vidal <nick@profian.com>