### PR TITLE
doc: add hackmd tag to the headers in the docs

### DIFF
--- a/docs/Practices/Design-Practices.md
+++ b/docs/Practices/Design-Practices.md
@@ -1,9 +1,12 @@
 # Design Practices
 
+[![hackmd-github-sync-badge](https://hackmd.io/RwifznZpTjSetxwo0JOjeA/badge)](https://hackmd.io/RwifznZpTjSetxwo0JOjeA)
+
+
 ###### tags: `Practices`
 | Author | Period | State |
 | -------- | -------- | -------- |
-| Dmitri Pal     | December, 2022 | :thumbsup: **Active**| 
+| Dmitri Pal     | December, 2022 | :thumbsup: **Active**|
 
 ## Overview
 
@@ -28,12 +31,12 @@ The goals of creating a design are:
 * Enabling future community contributors and team members to get up to speed faster.
 
 ## When a design document should be created?
-Creating a design document is a pretty heavy-weight process and has a lot of cost for the team. It is not required to create a design document for every feature or bug. On the other side, when a design is missing, it might lead to disagreements during reviews and a more complicated review process. 
+Creating a design document is a pretty heavy-weight process and has a lot of cost for the team. It is not required to create a design document for every feature or bug. On the other side, when a design is missing, it might lead to disagreements during reviews and a more complicated review process.
 
 The document must be created if any of the following situations applies:
 - The feature has a direct user impact, for example a change or addition of a public API, changes to a CLI or a change to configuration file syntax.
 - The feature has security implications. Any changes to security properties of the system or any of its components require a design document.
-- If a submitted PR leads to a discussion that requires more in depth conversation and agreement. In this case the work on the PR should be paused and a design document should be created and reviewed by the team. 
+- If a submitted PR leads to a discussion that requires more in depth conversation and agreement. In this case the work on the PR should be paused and a design document should be created and reviewed by the team.
 
 The owner of the feature should use the best judgment and decide whether to create the document or not. There is no silver bullet and there is a level of uncertainty that needs to be accepted. But it is a responsibility of the feature owner to recognize the need for a design as soon as possible and, if such need is identified, follow the described process.
 

--- a/docs/Practices/Document-Properties-Convention.md
+++ b/docs/Practices/Document-Properties-Convention.md
@@ -1,9 +1,12 @@
 # Document Properties Convention
 
-###### tags: `Practices` 
+[![hackmd-github-sync-badge](https://hackmd.io/cCeJHwjBSYyxlYx2PyWVFA/badge)](https://hackmd.io/cCeJHwjBSYyxlYx2PyWVFA)
+
+
+###### tags: `Practices`
 | Author | Period | State |
 | -------- | -------- | -------- |
-| Dmitri Pal | December, 2022 | :thumbsup: **Active** | 
+| Dmitri Pal | December, 2022 | :thumbsup: **Active** |
 
 ## Overview
 
@@ -16,12 +19,12 @@ Each document must include:
     * **Instructions** - documents that hold instructions. These documents stay in the HackMD portal.
     * **Notes** - documents that contain notes, this type is usually used as a temporary storage for information that shapes other types of documents. These documents stay in the HackMD portal and can be retired once the main document is polished.
     * **Meeting** - documents that hold meeting notes, outcomes or plans and proposed agenda for different meetings. These documents stay in the HackMD portal.
-    
+
 * A table in the format:
 
     | Author | Period | State |
     | -------- | -------- | -------- |
-    | &nbsp; | |  | 
+    | &nbsp; | |  |
 
     * **Author** - the name(s) of the author/owner of the document
     * **Period** - roughly a month and a year the document content is relevant to. One should read this as "at the mentioned time period the document reflected a reality". For example if the Period states: "May, 2023" and it is "June, 2023" one can assume that the document is recent and the related practices or implementation have not evolved or diverged. If the current date is "June, 2025" this means that the document and related practices might have not been reviewed and adjusted for a while and might require maintenance.


### PR DESCRIPTION
Added a tag linking code back to the document on HackMD.

This is the first test of pushing the documents from HackMD to git.
I removed some spaces at the ends of the lines and added tags that link the documents back to the HackMD pages.