### PR TITLE
chore: update to gtag

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -44,7 +44,7 @@ const config = {
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
-        googleAnalytics: {
+        gtag: {
           trackingID: 'G-5D36SLK3FB',
           anonymizeIP: true,
         },


### PR DESCRIPTION
Google Analytics Universal has been deprecated, so move to the new system.

Signed-off-by: Patrick Uiterwijk <patrick@profian.com>