### PR TITLE
Add mentions that meetings are on hold

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Participation in the Enarx community is governed by the [Contributor Covenant Co
 You can engage with us on the following channels:
 
 - [Chat](https://chat.enarx.dev)
-- [Meetings](https://enarx.dev/meetings)
+- [Meetings (on hold)](https://enarx.dev/meetings)
 
 ----
 

--- a/docs/Contributing/Introduction.md
+++ b/docs/Contributing/Introduction.md
@@ -28,7 +28,7 @@ All project discussion takes place on **Rocket Chat**. Feel free to drop in and 
 You can find us here: [chat.enarx.dev](https://chat.enarx.dev)
 
 
-## Meetings
+## Meetings (on hold)
 
 We have **daily meetings** at 10:00-10:30 EST, using [Google Meet](https://meet.google.com/uxk-ipyg-iui). No account is needed to join.
 

--- a/docs/Contributing/Onboarding.md
+++ b/docs/Contributing/Onboarding.md
@@ -35,7 +35,7 @@ You can see the Enarx issues [here](https://github.com/enarx/enarx/issues)
 ## Join the chat
 Join the chat at [chat.enarx.dev](https://chat.enarx.dev) and come say hi, ask questions, or just read the conversation.
 
-## Join meetings & board review
+## Join meetings & board review (on hold)
 
 The full Enarx calendar is available as a [Google Calendar](https://calendar.google.com/calendar/embed?src=leatqk15m1f34loatvatftkm48%40group.calendar.google.com&ctz=America%2FNew_York).
 

--- a/docs/Contributing/Resources.md
+++ b/docs/Contributing/Resources.md
@@ -46,7 +46,7 @@ We use "boards" to collect all issues related to one aspect of the project, such
 
 You can see the various boards (projects, in Github parlance) here: https://github.com/enarx/enarx/projects
 
-## Join meetings & board review
+## Join meetings & board review (on hold)
 Also mentioned on the main how to contribute page, we host regular meetings where you can come say hi, ask questions, or just listen to learn more about what's happening in the project.
 
 The full Enarx calendar is available as a [Google Calendar](https://calendar.google.com/calendar/embed?src=leatqk15m1f34loatvatftkm48%40group.calendar.google.com&ctz=America%2FNew_York).

--- a/src/pages/meetings.md
+++ b/src/pages/meetings.md
@@ -1,5 +1,7 @@
 # Meetings
 
+:warning: **Enarx used to have regular meetings, but they are currently on hold due to the closing of Profian.** :warning:
+
 ## Enarx Daily Meeting
 
 We have **daily meetings** at 10:00-10:30 EST, using [Google Meet](https://meet.google.com/uxk-ipyg-iui). No account is needed to join.


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

## 👨‍💻 Changes proposed

Add mentions that the Enarx meetings are on hold. I first thought about deleting the mention of meetings altogether but I thought on hold mentions would be better if the meetings were to restart / for history purposes. 

## ✔️ Check List (Check all the applicable boxes) <!-- Follow the below conventions to check the box -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

- [X] My code follows the code style of this project.
- [X] This PR does not contain plagiarized content.
- [X] The title of my pull request is a short description of the requested changes.
