### PR TITLE
feat: remove meeting information

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Participation in the Enarx community is governed by the [Contributor Covenant Co
 You can engage with us on the following channels:
 
 - [Chat](https://chat.enarx.dev)
-- [Meetings](https://enarx.dev/meetings)
+- [Discussions](https://github.com/orgs/enarx/discussions)
 
 ----
 

--- a/docs/Contributing/Introduction.md
+++ b/docs/Contributing/Introduction.md
@@ -17,7 +17,7 @@ We are happy to answer as best we can any question you have about Enarx.
 
 There are three ways you can ask questions:
 - using the chat (see the Communicating section below)
-- during one of the weekly meetings (see the Meetings section below)
+- using GitHub [discussions](https://github.com/orgs/enarx/discussions)
 - using the issue tracker (see the [How to contribute: issues reporting](Issues) page)
 
 Please use whatever method you are most comfortable with.
@@ -25,24 +25,12 @@ Please use whatever method you are most comfortable with.
 ## Communicating
 All project discussion takes place on **Rocket Chat**. Feel free to drop in and say hi!
 
-You can find us here: [chat.enarx.dev](https://chat.enarx.dev)
+You can find us here: [chat.enarx.dev](https://chat.enarx.dev) or get in touch on GitHub [discussions](https://github.com/orgs/enarx/discussions).
 
 
-## Meetings
+## Outreach
 
-We have **daily meetings** at 10:00-10:30 EST, using [Google Meet](https://meet.google.com/uxk-ipyg-iui). No account is needed to join.
-
-The full Enarx calendar is available as a [Google Calendar](https://calendar.google.com/calendar/embed?src=leatqk15m1f34loatvatftkm48%40group.calendar.google.com&ctz=America%2FNew_York). No account is needed to view.
-
-The meetings happen on [Google Meet](https://meet.google.com/uxk-ipyg-iui). (You do not need any account to join.)
-
-Please check the [Meetings](https://enarx.dev/meetings) page for more information.
-
-
-### Meeting structure and focus
-Our usual routine is to go through any new issues that have been opened since the last meeting (triage) then have a quick round-the-horn discussion of the team's daily activities. Newcomers are very welcome, if you have any questions don't hesitate to join.
-
-There is also an outreach meeting, on Tuesdays and Wednesdays fortnightly. More info on the [outreach](Outreach) page.
+You can have a look at the [outreach issues](https://github.com/enarx/outreach/issues) to find something that needs to be done!
 
 ## How to contribute, in various ways
 There are multiple ways you can contribute to the Enarx project.

--- a/docs/Contributing/Onboarding.md
+++ b/docs/Contributing/Onboarding.md
@@ -33,15 +33,7 @@ Github has several explainers on issues:
 You can see the Enarx issues [here](https://github.com/enarx/enarx/issues)
 
 ## Join the chat
-Join the chat at [chat.enarx.dev](https://chat.enarx.dev) and come say hi, ask questions, or just read the conversation.
-
-## Join meetings & board review
-
-The full Enarx calendar is available as a [Google Calendar](https://calendar.google.com/calendar/embed?src=leatqk15m1f34loatvatftkm48%40group.calendar.google.com&ctz=America%2FNew_York).
-
-The meetings happen on [Jitsi Meet](https://meet.jit.si/EnarxDaily). (You do not need any account to join.)
-
-Please check the [Meetings](https://enarx.dev/meetings) page for more information.
+Join the chat at [chat.enarx.dev](https://chat.enarx.dev) and come say hi, ask questions, or just read the conversation. We also have GitHub [discussions](https://github.com/orgs/enarx/discussions).
 
 ## Anything else?
 That's it! At this point, you should have everything you need to start contributing. If you feel anything is missing here, please let us know.

--- a/docs/Contributing/Resources.md
+++ b/docs/Contributing/Resources.md
@@ -46,23 +46,5 @@ We use "boards" to collect all issues related to one aspect of the project, such
 
 You can see the various boards (projects, in Github parlance) here: https://github.com/enarx/enarx/projects
 
-## Join meetings & board review
-Also mentioned on the main how to contribute page, we host regular meetings where you can come say hi, ask questions, or just listen to learn more about what's happening in the project.
-
-The full Enarx calendar is available as a [Google Calendar](https://calendar.google.com/calendar/embed?src=leatqk15m1f34loatvatftkm48%40group.calendar.google.com&ctz=America%2FNew_York).
-
-The meetings happen on [Jitsi Meet](https://meet.jit.si/EnarxDaily). (You do not need any account to join.)
-
-To join these meetings, you can:
-- open [the link](https://meet.jit.si/EnarxDaily) in your usual browser
-  -and give access to microphone and camera, as you see fit
-- download the Jitsi Meet mobile app (Android: [Google Play](https://play.google.com/store/apps/details?id=org.jitsi.meet) or [F-Droid](https://f-droid.org/en/packages/org.jitsi.meet/), [iOS](https://apps.apple.com/us/app/jitsi-meet/id1165103905)
-  -  then enter the meeting ID (`EnarxDaily`)
-- dial-in by phone: +1.512.647.1431,,3117518640# or [visit this link](https://meet.jit.si/static/dialInInfo.html?room=EnarxDaily) to see more numbers.
-
-
-### In-meeting tips:
-- when someone's screen is being presented, you can click layout button at the bottom of the interface to switch layouts and get more in your screen (the four squares titled "Toggle tile view").
-
 ## Anything else?
 That's it! At this point, you should have everything you need to start contributing. If you feel anything is missing here, please let us know.

--- a/docs/Practices/Project-Management-Practices.md
+++ b/docs/Practices/Project-Management-Practices.md
@@ -60,23 +60,6 @@ We will conduct triage of the incoming issues during the daily "Status call" if 
  * We will create release branches foe every release where we bump major or minor version.
  * Sprint starts on **Wednesday**
 
-## Meetings
-* Daily Status Meetings - daily 10Am EST
-
-| Day | First week | Second week |
-|-------- | -------- | -------- |
-|Wednesday|Sprint kickoff|(Feature Freeze) Normal triage/status|
-|Thursday|Normal triage/status|Normal triage/status|
-|Friday|Normal triage/status|Normal triage/status|
-|Monday|Demo + triage/status|Demo + triage/status + release prep|
-|Tuesday|Normal triage/status|Sprint wrap up/Release party|
-
-* Design meeting - Thursdays 9am EST
-
-| First week | Second week |
-|-------- | -------- |
-| Retrospective of the previous sprint | Actual design session |
-
 ## Roles
 
 * **Project coordinator** - this is the role similar to scrum master/project manager. It can be a rotating role. The person is responsible for making sure all the rituals are followed as described and the team knows what needs to be done and when.

--- a/src/pages/meetings.md
+++ b/src/pages/meetings.md
@@ -2,37 +2,14 @@
 
 ## Enarx Daily Meeting
 
-We have **daily meetings** at 10:00-10:30 EST, using [Google Meet](https://meet.google.com/uxk-ipyg-iui). No account is needed to join.
-
-The full Enarx calendar is available as a [Google Calendar](https://calendar.google.com/calendar/embed?src=leatqk15m1f34loatvatftkm48%40group.calendar.google.com&ctz=America%2FNew_York). No account is needed to view.
-
-To join these meetings, you can:
-- access online: [open this link](https://meet.google.com/uxk-ipyg-iui) in your usual browser and give access to microphone and camera, as you see fit
-- dial-in by phone: [visit this link](https://tel.meet/uxk-ipyg-iui?pin=5101436873391) to see more numbers.
-
-Like everything else Enarx, these meetings are fully public, and you are more than welcome to join us. If you're a new attendee, please introduce yourself! We promise we won't bite. :slightly_smiling_face: We'll also be happy to answer any questions you may have or engage in any discussions you want to bring up about the project.
-
-Our usual routine is to go through any new issues that have been opened since the last meeting (triage) then have a quick round-the-horn discussion of the team's daily activities.
-
-Newcomers are very welcome, if you have any questions don't hesitate to join.
-
-## Enarx Outreach Meeting
-
-There is also an outreach meeting on Tuesdays at 13:00 EST at the following Jitsi Meet room:
-
-https://meet.jit.si/EnarxOutreach
-
-The goal of the Outreach meetings is to help promote the Enarx project, including discussing:
-- articles
-- public speaking at conferences
-- exposition hall booths at conferences
-- social media
-
-You can have a look at the [outreach issues](https://github.com/enarx/outreach/issues) to find something that needs to be done!
-
+The Enarx community used to have regular meetings, but these have been discontinued.
 
 ## Past Meetings
 
 Notes from past meetings are available at:
 
 https://enarx.dev/resources/tags/meeting
+
+Instead, please reach out via:
+- [chat](https://chat.enarx.dev)
+- [discussions](https://github.com/orgs/enarx/discussions)


### PR DESCRIPTION
* Meetings can be re-added if resumed.
* Mention GitHub discussions in addition to chat.

Thanks to @mh4ck-Thales for pushing for this long overdue website update!
